### PR TITLE
Fix Escape not exiting display fullscreen (Windows)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murmure",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murmure",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "electron-store": "^8.2.0",

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, ipcMain, screen, shell, globalShortcut } from 'electron';
+import { BrowserWindow, ipcMain, screen, shell } from 'electron';
 import { IPC, type ApiKeyTestResult, type DisplayState, type MockState, type StreamState } from '../shared/ipc';
 import { ASSEMBLY_DASHBOARD_URL } from '../shared/constants';
 import {
@@ -58,6 +58,17 @@ function getDisplayState(): DisplayState {
 
 function broadcastDisplayState(): void {
   broadcast(IPC.DisplayState, getDisplayState());
+}
+
+function attachEscapeToExitFullscreen(window: BrowserWindow): void {
+  window.webContents.on('before-input-event', (event, input) => {
+    if (input.type !== 'keyDown' || input.key !== 'Escape') return;
+    const dw = ctx.displayWindow;
+    if (dw && !dw.isDestroyed() && dw.isFullScreen()) {
+      dw.setFullScreen(false);
+      event.preventDefault();
+    }
+  });
 }
 
 function setMockEnabled(enabled: boolean): void {
@@ -176,6 +187,7 @@ export function registerIpc(controlWindow: BrowserWindow): void {
     win.on('enter-full-screen', broadcastDisplayState);
     win.on('leave-full-screen', broadcastDisplayState);
     win.on('move', broadcastDisplayState);
+    attachEscapeToExitFullscreen(win);
     return getDisplayState();
   });
   ipcMain.handle(IPC.DisplayClose, () => {
@@ -200,24 +212,13 @@ export function registerIpc(controlWindow: BrowserWindow): void {
     return { ok: true };
   });
 
-  // global Escape to exit fullscreen on display window when focused
-  controlWindow.on('focus', () => {
-    // do not register escape on control window
-  });
-
-  const registerEscape = () => {
-    try {
-      globalShortcut.register('Escape', () => {
-        const dw = ctx.displayWindow;
-        if (dw && !dw.isDestroyed() && dw.isFullScreen() && dw.isFocused()) {
-          dw.setFullScreen(false);
-        }
-      });
-    } catch {
-      // ignore — already registered
-    }
-  };
-  registerEscape();
+  // Escape exits the display fullscreen, listened on each window's webContents.
+  // Using before-input-event (instead of globalShortcut) avoids hijacking
+  // Escape system-wide and works reliably on Windows, where globalShortcut
+  // for Escape is unreliable. The handler fires on whichever window is
+  // focused, so the operator can press Escape from the control window even
+  // when the display is fullscreen on another monitor.
+  attachEscapeToExitFullscreen(controlWindow);
 
   // toast on screen change
   screen.on('display-added', () => {


### PR DESCRIPTION
## What

Fix the Escape key not exiting display fullscreen — most visibly on Windows 11 where the failure is consistent.

Closes #2.

## Why

The previous handler used `globalShortcut.register('Escape', ...)` gated by `displayWindow.isFocused()`. Two problems with that:

1. **Focus mismatch.** When the operator is interacting with the control window (the common case while the display is fullscreen on a second monitor), the display window isn't focused. The handler silently dropped the Escape press.
2. **Windows quirk.** `globalShortcut` for Escape is notoriously unreliable on Windows — registration often silently fails, so even when the display *did* have focus, the shortcut never fired.

Reported by @Chaveex (technical Windows 11 user).

## How I fixed it

Replaced `globalShortcut` with `webContents.on('before-input-event', ...)` attached to **both** windows (control and display). Each window listens for Escape when it has focus and, if the display window is currently fullscreen, exits fullscreen and `event.preventDefault()`s the input.

This:
- works reliably on Windows / macOS / Linux,
- doesn't hijack Escape system-wide (other apps still receive it normally),
- handles the operator's real workflow: pressing Escape from the control window while watching the display on the second screen.

## How to verify

On Windows 11 (the reported environment) and macOS:

1. `npm install && npm run dev` (or install the new \`.exe\` once a release is cut)
2. Click **Open display / Ouvrir l'affichage** with a second monitor connected — the display window goes fullscreen there.
3. Click on the control window so it has focus, then press **Escape**. The display should exit fullscreen.
4. Click into the display window so it has focus, then press **Escape**. Same — it should exit fullscreen.
5. With no fullscreen active, Escape should be a no-op (i.e. don't break Escape for other UI elements).

## Notes

@Chaveex — would you mind testing this once it's released? I'll cut a release tag after merge so a fresh \`.exe\` lands on the [Releases page](https://github.com/KevinGallaccio/murmure/releases). Reply on this PR or on issue #2 with whether Escape works for you in both scenarios above. Thanks for the report!