### PR TITLE
Build .zip alongside .dmg so macOS auto-update works

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -10,7 +10,15 @@ files:
 asar: true
 mac:
   target:
+    # The .dmg is the user-facing installer (downloaded from the Releases page).
     - target: dmg
+      arch:
+        - universal
+    # The .zip is required by electron-updater for in-place auto-updates on
+    # macOS — a running .app can't be atomically replaced from a mounted .dmg,
+    # so the updater downloads and unpacks the .zip instead. Without this,
+    # auto-update fails with "ZIP file not provided".
+    - target: zip
       arch:
         - universal
   category: public.app-category.utilities


### PR DESCRIPTION
## What

Add the \`zip\` target to the macOS build matrix in \`electron-builder.yml\` so every release publishes both \`.dmg\` and \`.zip\` artifacts.

Closes #5.

## Why

\`electron-updater\` on macOS **requires** a \`.zip\` artifact in addition to the \`.dmg\`. The two have different roles:

- The **.dmg** is the user-facing installer downloaded from the Releases page.
- The **.zip** is what the auto-updater fetches behind the scenes — a running \`.app\` can't be atomically swapped out from a mounted \`.dmg\`, but it can be from an unzip-then-replace operation.

Without the zip target, \`latest-mac.yml\` lists no zip, and the updater on existing installs fails with the literal error \`ZIP file not provided\` — exactly what was seen on v1.0.4.

## How to verify

After this is merged and v1.0.5 is tagged:

1. Confirm the v1.0.5 release page shows **both** \`murmure-1.0.5-universal.dmg\` and \`murmure-1.0.5-universal-mac.zip\` (plus the usual \`.blockmap\` and \`latest-mac.yml\` files).
2. On the v1.0.4 install: open the app → check for updates from the menu → it should now find v1.0.5 and the download/install should succeed instead of erroring.
3. After it installs, the titlebar version reads \`v 1.0.5\`.

## Notes

- This change is build-config only; no runtime behaviour changes.
- The Windows side (\`.exe\` + \`.blockmap\`) was already correct because NSIS supports in-place updates natively.
- For the v1.0.4 → v1.0.5 update specifically: the v1.0.4 client's updater is what's broken, but it can still download and apply a v1.0.5 zip once the new release publishes one. So existing installs aren't permanently stuck — they just need v1.0.5 to ship.