### PR TITLE
Localize the macOS app menu (FR / EN, follows OS locale)

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,8 +1,89 @@
 import { app, Menu, shell, type BrowserWindow, type MenuItemConstructorOptions } from 'electron';
 import { checkForUpdatesInteractive } from './updater';
 
+// Same approach as src/main/updater.ts: dialogs and menu labels live in the
+// main process, which can't read the renderer's i18n state. We pick the menu
+// language from the OS locale so an English Mac shows English menus, a French
+// Mac shows French menus. (If the user explicitly toggled the in-app FR/EN
+// switch to something different from their OS, the menu still follows the OS —
+// acceptable trade-off until the renderer's locale is plumbed through to main.)
+type MenuLocale = 'fr' | 'en';
+
+function getMenuLocale(): MenuLocale {
+  const sys = (app.getLocale() || '').toLowerCase();
+  return sys.startsWith('en') ? 'en' : 'fr';
+}
+
+const STRINGS = {
+  fr: {
+    appAbout: `À propos de ${app.name}`,
+    appCheckUpdates: 'Vérifier les mises à jour…',
+    appServices: 'Services',
+    appHide: `Masquer ${app.name}`,
+    appHideOthers: 'Masquer les autres',
+    appUnhide: 'Tout afficher',
+    appQuit: `Quitter ${app.name}`,
+    edit: 'Édition',
+    editUndo: 'Annuler',
+    editRedo: 'Rétablir',
+    editCut: 'Couper',
+    editCopy: 'Copier',
+    editPaste: 'Coller',
+    editSelectAll: 'Tout sélectionner',
+    view: 'Affichage',
+    viewReload: 'Recharger',
+    viewForceReload: 'Forcer le rechargement',
+    viewDevTools: 'Outils de développement',
+    viewActualSize: 'Taille réelle',
+    viewZoomIn: 'Zoom avant',
+    viewZoomOut: 'Zoom arrière',
+    viewFullscreen: 'Plein écran',
+    window: 'Fenêtre',
+    windowMinimize: 'Réduire',
+    windowZoom: 'Zoom',
+    windowFront: 'Tout ramener au premier plan',
+    windowClose: 'Fermer',
+    help: 'Aide',
+    helpDocs: 'Documentation',
+    helpReport: 'Signaler un problème',
+  },
+  en: {
+    appAbout: `About ${app.name}`,
+    appCheckUpdates: 'Check for Updates…',
+    appServices: 'Services',
+    appHide: `Hide ${app.name}`,
+    appHideOthers: 'Hide Others',
+    appUnhide: 'Show All',
+    appQuit: `Quit ${app.name}`,
+    edit: 'Edit',
+    editUndo: 'Undo',
+    editRedo: 'Redo',
+    editCut: 'Cut',
+    editCopy: 'Copy',
+    editPaste: 'Paste',
+    editSelectAll: 'Select All',
+    view: 'View',
+    viewReload: 'Reload',
+    viewForceReload: 'Force Reload',
+    viewDevTools: 'Developer Tools',
+    viewActualSize: 'Actual Size',
+    viewZoomIn: 'Zoom In',
+    viewZoomOut: 'Zoom Out',
+    viewFullscreen: 'Toggle Full Screen',
+    window: 'Window',
+    windowMinimize: 'Minimize',
+    windowZoom: 'Zoom',
+    windowFront: 'Bring All to Front',
+    windowClose: 'Close',
+    help: 'Help',
+    helpDocs: 'Documentation',
+    helpReport: 'Report an Issue',
+  },
+} as const;
+
 export function createAppMenu(getControlWindow: () => BrowserWindow | null): Menu {
   const isMac = process.platform === 'darwin';
+  const t = STRINGS[getMenuLocale()];
 
   const template: MenuItemConstructorOptions[] = [];
 
@@ -11,81 +92,81 @@ export function createAppMenu(getControlWindow: () => BrowserWindow | null): Men
     template.push({
       label: app.name,
       submenu: [
-        { role: 'about', label: 'À propos de murmure' },
+        { role: 'about', label: t.appAbout },
         { type: 'separator' },
         {
-          label: 'Vérifier les mises à jour…',
+          label: t.appCheckUpdates,
           click: () => {
             checkForUpdatesInteractive(getControlWindow());
           },
         },
         { type: 'separator' },
-        { role: 'services', label: 'Services' },
+        { role: 'services', label: t.appServices },
         { type: 'separator' },
-        { role: 'hide', label: 'Masquer murmure' },
-        { role: 'hideOthers', label: 'Masquer les autres' },
-        { role: 'unhide', label: 'Tout afficher' },
+        { role: 'hide', label: t.appHide },
+        { role: 'hideOthers', label: t.appHideOthers },
+        { role: 'unhide', label: t.appUnhide },
         { type: 'separator' },
-        { role: 'quit', label: 'Quitter murmure' },
+        { role: 'quit', label: t.appQuit },
       ],
     });
   }
 
   // Edit menu
   template.push({
-    label: 'Édition',
+    label: t.edit,
     submenu: [
-      { role: 'undo', label: 'Annuler' },
-      { role: 'redo', label: 'Rétablir' },
+      { role: 'undo', label: t.editUndo },
+      { role: 'redo', label: t.editRedo },
       { type: 'separator' },
-      { role: 'cut', label: 'Couper' },
-      { role: 'copy', label: 'Copier' },
-      { role: 'paste', label: 'Coller' },
-      { role: 'selectAll', label: 'Tout sélectionner' },
+      { role: 'cut', label: t.editCut },
+      { role: 'copy', label: t.editCopy },
+      { role: 'paste', label: t.editPaste },
+      { role: 'selectAll', label: t.editSelectAll },
     ],
   });
 
   // View menu
   template.push({
-    label: 'Affichage',
+    label: t.view,
     submenu: [
-      { role: 'reload', label: 'Recharger' },
-      { role: 'forceReload', label: 'Forcer le rechargement' },
-      { role: 'toggleDevTools', label: 'Outils de développement' },
+      { role: 'reload', label: t.viewReload },
+      { role: 'forceReload', label: t.viewForceReload },
+      { role: 'toggleDevTools', label: t.viewDevTools },
       { type: 'separator' },
-      { role: 'resetZoom', label: 'Taille réelle' },
-      { role: 'zoomIn', label: 'Zoom avant' },
-      { role: 'zoomOut', label: 'Zoom arrière' },
+      { role: 'resetZoom', label: t.viewActualSize },
+      { role: 'zoomIn', label: t.viewZoomIn },
+      { role: 'zoomOut', label: t.viewZoomOut },
       { type: 'separator' },
-      { role: 'togglefullscreen', label: 'Plein écran' },
+      { role: 'togglefullscreen', label: t.viewFullscreen },
     ],
   });
 
   // Window menu
   template.push({
-    label: 'Fenêtre',
+    label: t.window,
     submenu: [
-      { role: 'minimize', label: 'Réduire' },
-      { role: 'zoom', label: 'Zoom' },
+      { role: 'minimize', label: t.windowMinimize },
+      { role: 'zoom', label: t.windowZoom },
       ...(isMac
         ? [
             { type: 'separator' } as MenuItemConstructorOptions,
-            { role: 'front', label: 'Tout ramener au premier plan' } as MenuItemConstructorOptions,
+            { role: 'front', label: t.windowFront } as MenuItemConstructorOptions,
           ]
-        : [{ role: 'close', label: 'Fermer' } as MenuItemConstructorOptions]),
+        : [{ role: 'close', label: t.windowClose } as MenuItemConstructorOptions]),
     ],
   });
 
   // Help menu
   const helpSubmenu: MenuItemConstructorOptions[] = [
     {
-      label: 'Documentation',
+      label: t.helpDocs,
       click: () => {
         shell.openExternal('https://github.com/KevinGallaccio/murmure#readme');
       },
     },
     {
-      label: 'Signaler un problème',
+      label: t.helpReport,
       click: () => {
         shell.openExternal('https://github.com/KevinGallaccio/murmure/issues');
       },
@@ -97,7 +178,7 @@ export function createAppMenu(getControlWindow: () => BrowserWindow | null): Men
     helpSubmenu.push(
       { type: 'separator' },
       {
-        label: 'Vérifier les mises à jour…',
+        label: t.appCheckUpdates,
         click: () => {
           checkForUpdatesInteractive(getControlWindow());
         },
@@ -106,7 +187,7 @@ export function createAppMenu(getControlWindow: () => BrowserWindow | null): Men
   }
 
   template.push({
-    label: 'Aide',
+    label: t.help,
     role: 'help',
     submenu: helpSubmenu,
   });


### PR DESCRIPTION
## What

Translate the native macOS menu (App / Edit / View / Window / Help and all their items) based on \`app.getLocale()\`, so an English Mac shows English menus and a French Mac shows French menus.

## Why

The menu was hardcoded French even when the app was running in English on an English Mac. Reported by Kevin in #5 follow-up — screenshot showed *Édition / Affichage / Fenêtre / Aide / Quitter murmure / Vérifier les mises à jour…* on an English-locale system.

This is the same kind of bug as the updater dialogs fixed in #7: main-process strings don't have access to the renderer's i18n state, so they need to source language separately. Same fix pattern — bilingual table + \`app.getLocale()\` — applied to \`menu.ts\`.

## How I fixed it

Mirrored the updater approach exactly:

\`\`\`ts
const STRINGS = {
  fr: { appAbout: 'À propos de murmure', appQuit: 'Quitter murmure', edit: 'Édition', /* … */ },
  en: { appAbout: 'About murmure',       appQuit: 'Quit murmure',    edit: 'Edit',     /* … */ },
} as const;

function getMenuLocale(): MenuLocale {
  const sys = (app.getLocale() || '').toLowerCase();
  return sys.startsWith('en') ? 'en' : 'fr';
}
\`\`\`

Then every menu \`label:\` reads from \`t.…\` instead of a hardcoded string.

## How to verify

1. **English Mac**: open the new build → top menu bar should read *murmure / Edit / View / Window / Help*. Items: *About murmure*, *Check for Updates…*, *Quit murmure*, *Cut / Copy / Paste*, *Reload / Force Reload / Developer Tools*, *Toggle Full Screen*, etc.
2. **French Mac**: same flow, in French — same as before.
3. **Windows / Linux**: no menu bar exists in the same way; the Help menu still gets the *Check for Updates…* item, also localized.

## Note

Same OS-vs-app-toggle trade-off as the updater PR — menu follows OS locale, not the in-app FR/EN switch. If anyone hits the edge case where they want OS-French + app-English (or vice versa), the proper fix is to plumb the renderer's locale through to main via IPC. Easy follow-up.