### PR TITLE
Redesign polish: rephrase Appearance title (FR), remove duplicate titlebar

### DIFF
--- a/src/renderer-control/App.tsx
+++ b/src/renderer-control/App.tsx
@@ -352,27 +352,6 @@ export function App(): JSX.Element {
 
   return (
     <div className="app">
-      <header className="titlebar">
-        <div />
-        <div className="title">murmure</div>
-        <div className="titlebar-right">
-          <span className="rec">
-            <span
-              className="dot"
-              style={{
-                background: streamState === 'streaming' ? 'var(--brand)' : 'var(--ink-4)',
-                width: 6,
-                height: 6,
-                boxShadow: 'none',
-              }}
-            />
-            {streamState === 'streaming' ? 'rec' : 'idle'}
-          </span>
-          <span>·</span>
-          <span>v 1.1.0</span>
-        </div>
-      </header>
-
       <div className="body">
         <Sidebar
           tab={tab}

--- a/src/renderer-control/i18n.tsx
+++ b/src/renderer-control/i18n.tsx
@@ -180,8 +180,8 @@ const fr: Messages = {
   },
   appearance: {
     eyebrow: 'Apparence',
-    titleA: 'Comment la salle ',
-    titleEm: 'lit',
+    titleA: 'Ce que voit votre ',
+    titleEm: 'audience',
     titleB: '.',
     sub: "Réglez l'écran d'audience pour qu'il fonctionne pour le dernier rang. Les modifications s'appliquent en direct.",
     previewTitle: 'Aperçu pour le public',

--- a/src/renderer-control/styles.css
+++ b/src/renderer-control/styles.css
@@ -143,43 +143,8 @@ a { color: var(--brand); text-decoration: none; }
 
 /* App shell ------------------------------------------------- */
 .app {
-  display: grid;
-  grid-template-rows: 38px 1fr;
   height: 100vh;
   background: var(--paper);
-}
-
-/* Titlebar -------------------------------------------------- */
-.titlebar {
-  height: 38px;
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center;
-  padding: 0 14px;
-  background: var(--paper-2);
-  border-bottom: 1px solid var(--line);
-  -webkit-app-region: drag;
-}
-.titlebar .title {
-  font-size: 12px;
-  color: var(--ink-3);
-  letter-spacing: 0.02em;
-  text-align: center;
-}
-.titlebar-right {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  gap: 10px;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--ink-4);
-  -webkit-app-region: no-drag;
-}
-.titlebar-right .rec {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
 }
 
 /* Body grid ------------------------------------------------- */


### PR DESCRIPTION
Two small follow-ups to the v1.1.0 redesign.

## 1. Appearance title in French

Replaces the literal 'Comment la salle lit.' (which reads as incomplete to native speakers — *la salle lit quoi?*) with **'Ce que voit votre _audience_.'** — direct, idiomatic, addresses the operator's intent. Italicised noun is *audience* to match the brand-colored emphasis pattern of the other tab titles.

The Stage page caption 'Ce que voit le public' is kept as-is — different register (small caption vs. editorial title) and the two reinforce each other.

## 2. Remove the duplicate custom titlebar

The macOS native titlebar already shows 'murmure' (from BrowserWindow's `title`) centered next to the traffic lights, and the sidebar already shows the logo + wordmark + version + broadcast / display state. The custom titlebar in between was repeating both. Removing it lets the body grid start directly under the OS chrome — cleaner and not redundant.

Both changes are small enough to land together; CI gates the bundle.