### PR TITLE
Force endpoint after 5s of uninterrupted speech (issue #14)

### DIFF
--- a/src/main/assemblyai-client.ts
+++ b/src/main/assemblyai-client.ts
@@ -1,5 +1,10 @@
 import WebSocket from 'ws';
-import { ASSEMBLY_PARAMS, ASSEMBLY_WS_BASE, RECONNECT_BACKOFF_MS } from '../shared/constants';
+import {
+  ASSEMBLY_PARAMS,
+  ASSEMBLY_WS_BASE,
+  FORCE_ENDPOINT_MS,
+  RECONNECT_BACKOFF_MS,
+} from '../shared/constants';
 import type { StreamErrorPayload, StreamState, TranscriptFinal, TranscriptPartial } from '../shared/ipc';
 
 export type AssemblyAIClientCallbacks = {
@@ -25,6 +30,7 @@ export class AssemblyAIClient {
   private explicitlyStopped = false;
   private lastTurnId: string = '';
   private currentTurnText = '';
+  private forceEndpointTimer: NodeJS.Timeout | null = null;
 
   constructor(private readonly cb: AssemblyAIClientCallbacks) {}
 
@@ -40,6 +46,7 @@ export class AssemblyAIClient {
 
   stop(): void {
     this.explicitlyStopped = true;
+    this.clearForceEndpoint();
     if (this.ws) {
       try {
         this.ws.send(JSON.stringify({ type: 'Terminate' }));
@@ -166,6 +173,7 @@ export class AssemblyAIClient {
     this.ws = ws;
     this.lastTurnId = '';
     this.currentTurnText = '';
+    this.clearForceEndpoint();
 
     ws.on('open', () => {
       // wait for Begin event before declaring streaming
@@ -223,9 +231,15 @@ export class AssemblyAIClient {
         if (turnId !== this.lastTurnId) {
           this.lastTurnId = turnId;
           this.currentTurnText = '';
+          // New turn detected — start the watchdog. If this turn keeps
+          // growing for FORCE_ENDPOINT_MS without committing, we'll force
+          // AssemblyAI to commit it so the audience sees the text before
+          // the speaker finally pauses.
+          this.scheduleForceEndpoint();
         }
         const text = turnEv.transcript ?? '';
         if (turnEv.end_of_turn && turnEv.turn_is_formatted) {
+          this.clearForceEndpoint();
           this.cb.onFinal({ text, turnId, timestamp: Date.now() });
           this.currentTurnText = '';
         } else if (!turnEv.end_of_turn) {
@@ -254,6 +268,28 @@ export class AssemblyAIClient {
   private transitionTo(next: StreamState): void {
     if (this.state === next) return;
     this.state = next;
+    if (next !== 'streaming') this.clearForceEndpoint();
     this.cb.onStateChange(next);
+  }
+
+  private scheduleForceEndpoint(): void {
+    this.clearForceEndpoint();
+    this.forceEndpointTimer = setTimeout(() => {
+      this.forceEndpointTimer = null;
+      if (this.ws && this.ws.readyState === WebSocket.OPEN && this.state === 'streaming') {
+        try {
+          this.ws.send(JSON.stringify({ type: 'ForceEndpoint' }));
+        } catch (err) {
+          console.error('[murmure] ForceEndpoint send failed', err);
+        }
+      }
+    }, FORCE_ENDPOINT_MS);
+  }
+
+  private clearForceEndpoint(): void {
+    if (this.forceEndpointTimer) {
+      clearTimeout(this.forceEndpointTimer);
+      this.forceEndpointTimer = null;
+    }
   }
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -22,6 +22,13 @@ export const DEFAULT_RATE_PER_HOUR = 0.45;
 
 export const RECONNECT_BACKOFF_MS = [1000, 2000, 4000];
 
+// If the current turn has been growing for this long without a final, send
+// a ForceEndpoint to AssemblyAI to commit what's there. Without this, very
+// long pause-free monologues (e.g. fast-paced podcast guests) only commit
+// after the speaker finally breathes — and arrive on screen as one
+// hard-to-follow block.
+export const FORCE_ENDPOINT_MS = 5000;
+
 export const USAGE_CHECKPOINT_INTERVAL_MS = 30_000;
 
 export const MOCK_FRENCH_LINES = [


### PR DESCRIPTION
Closes #14.

## What

Add a watchdog timer in `AssemblyAIClient`. When a new turn starts and doesn't commit a final within `FORCE_ENDPOINT_MS` (default **5 seconds**), send the AssemblyAI control message `{ type: 'ForceEndpoint' }` to commit the current partial and start a new turn.

## Why

AssemblyAI's u3-rt-pro is turn-based: a final commits only when the model detects end-of-turn (silence). For fast podcast hosts who barely pause, turns can stretch 10–20+ seconds, and the audience sees nothing on screen until the speaker finally breathes. The whole block then lands at once, in a wall, unreadable.

The two existing knobs (`max_turn_silence: 1400ms` + `min_end_of_turn_silence_when_confident: 100ms`) help when the speaker takes *any* pauses. They can't help when there are none.

## How

- New `FORCE_ENDPOINT_MS = 5000` constant in `shared/constants.ts` so it's trivial to tune.
- New private `forceEndpointTimer` field on `AssemblyAIClient`.
- New helpers `scheduleForceEndpoint()` / `clearForceEndpoint()`.
- Schedule on **new turn detected** in `handleEvent` for `'Turn'`.
- Clear on **final received**, on `stop()`, on `connect()` (fresh start), and on transition out of `'streaming'` state.

## How to verify

1. Start a broadcast and read aloud for ~15 seconds without breathing pauses (sing-song a paragraph, recite a fast tongue-twister, etc.).
2. **Before this change:** screen stays empty until you finally pause; then a giant block appears.
3. **After this change:** roughly every 5 seconds the partial gets force-committed and you see a chunk of text land on screen, scrolling forward.

## Tuning

If 5 s feels still too long for your podcast cadence, drop `FORCE_ENDPOINT_MS` to `3000` or `4000` in `src/shared/constants.ts`. If you see too many tiny final fragments mid-sentence, raise to `6000` or `7000`. No setting yet in the UI — by design, this is a stream-tuning concern, not an end-user one.