### PR TITLE
Configurable force-endpoint threshold (Setup tab)

### DIFF
--- a/src/main/assemblyai-client.ts
+++ b/src/main/assemblyai-client.ts
@@ -1,11 +1,7 @@
 import WebSocket from 'ws';
-import {
-  ASSEMBLY_PARAMS,
-  ASSEMBLY_WS_BASE,
-  FORCE_ENDPOINT_MS,
-  RECONNECT_BACKOFF_MS,
-} from '../shared/constants';
+import { ASSEMBLY_PARAMS, ASSEMBLY_WS_BASE, RECONNECT_BACKOFF_MS } from '../shared/constants';
 import type { StreamErrorPayload, StreamState, TranscriptFinal, TranscriptPartial } from '../shared/ipc';
+import { getAssemblyConfig } from './settings';
 
 export type AssemblyAIClientCallbacks = {
   onStateChange: (state: StreamState) => void;
@@ -274,6 +270,10 @@ export class AssemblyAIClient {
 
   private scheduleForceEndpoint(): void {
     this.clearForceEndpoint();
+    // Read the threshold each schedule so changes from the Setup UI take
+    // effect on the next turn without needing to reconnect.
+    const ms = getAssemblyConfig().forceEndpointMs;
+    if (ms === null || ms <= 0) return; // user disabled the watchdog
     this.forceEndpointTimer = setTimeout(() => {
       this.forceEndpointTimer = null;
       if (this.ws && this.ws.readyState === WebSocket.OPEN && this.state === 'streaming') {
@@ -283,7 +283,7 @@ export class AssemblyAIClient {
           console.error('[murmure] ForceEndpoint send failed', err);
         }
       }
-    }, FORCE_ENDPOINT_MS);
+    }, ms);
   }
 
   private clearForceEndpoint(): void {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -2,6 +2,7 @@ import { BrowserWindow, ipcMain, screen, shell } from 'electron';
 import {
   IPC,
   type ApiKeyTestResult,
+  type AssemblyConfigPayload,
   type DisplayState,
   type LanguageChoice,
   type LanguageState,
@@ -14,6 +15,7 @@ import { ASSEMBLY_DASHBOARD_URL } from '../shared/constants';
 import {
   clearApiKey,
   getApiKey,
+  getAssemblyConfig,
   getLanguageChoice,
   getStyleSettings,
   getTheme,
@@ -21,6 +23,7 @@ import {
   resetStyle,
   resolveLocale,
   saveApiKey,
+  setAssemblyConfig,
   setLanguageChoice,
   setTheme,
   updateStyle,
@@ -265,6 +268,13 @@ export function registerIpc(controlWindow: BrowserWindow): void {
     broadcast(IPC.LanguageChanged, state);
     languageChangeListeners.forEach((cb) => cb(state));
     return state;
+  });
+
+  ipcMain.handle(IPC.AssemblyConfigGet, () => getAssemblyConfig());
+  ipcMain.handle(IPC.AssemblyConfigSet, (_e, payload: AssemblyConfigPayload) => {
+    const next = setAssemblyConfig(payload);
+    broadcast(IPC.AssemblyConfigChanged, next);
+    return next;
   });
 
   // Escape exits the display fullscreen, listened on each window's webContents.

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -10,12 +10,24 @@ export type SessionRecord = {
   seconds: number;
 };
 
+export type AssemblyConfig = {
+  // Watchdog: if a turn keeps growing for this long (ms) without a final,
+  // send ForceEndpoint to commit the current partial. null = disabled, rely
+  // entirely on natural end-of-turn detection. 0 < n < 60_000 are valid.
+  forceEndpointMs: number | null;
+};
+
+export const DEFAULT_ASSEMBLY_CONFIG: AssemblyConfig = {
+  forceEndpointMs: 5000,
+};
+
 export type PersistedState = {
   apiKey: { ciphertext: string } | null;
   selectedDeviceId: string | null;
   style: StyleSettings;
   theme: Theme;
   language: LanguageChoice;
+  assembly: AssemblyConfig;
   usage: {
     totalSeconds: number;
     sessions: SessionRecord[];
@@ -30,6 +42,7 @@ const initialState: PersistedState = {
   style: DEFAULT_STYLE,
   theme: 'light',
   language: 'auto',
+  assembly: DEFAULT_ASSEMBLY_CONFIG,
   usage: {
     totalSeconds: 0,
     sessions: [],
@@ -167,4 +180,14 @@ export function resolveLocale(choice: LanguageChoice = getLanguageChoice()): Res
   // French region setting).
   const sys = (app.getSystemLocale?.() || app.getLocale() || '').toLowerCase();
   return sys.startsWith('fr') ? 'fr' : 'en';
+}
+
+export function getAssemblyConfig(): AssemblyConfig {
+  return { ...DEFAULT_ASSEMBLY_CONFIG, ...(store.get('assembly') ?? {}) };
+}
+
+export function setAssemblyConfig(partial: Partial<AssemblyConfig>): AssemblyConfig {
+  const next = { ...getAssemblyConfig(), ...partial };
+  store.set('assembly', next);
+  return next;
 }

--- a/src/preload/control.ts
+++ b/src/preload/control.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron';
 import type {
   ApiKeyStatus,
   ApiKeyTestResult,
+  AssemblyConfigPayload,
   DisplayInfo,
   DisplayState,
   LanguageChoice,
@@ -85,6 +86,13 @@ const api = {
   },
   tab: {
     onNavigate: (cb: (t: Tab) => void) => subscribe<Tab>(IPC.TabNavigate, cb),
+  },
+  assembly: {
+    get: (): Promise<AssemblyConfigPayload> => ipcRenderer.invoke(IPC.AssemblyConfigGet),
+    set: (cfg: AssemblyConfigPayload): Promise<AssemblyConfigPayload> =>
+      ipcRenderer.invoke(IPC.AssemblyConfigSet, cfg),
+    onChange: (cb: (cfg: AssemblyConfigPayload) => void) =>
+      subscribe<AssemblyConfigPayload>(IPC.AssemblyConfigChanged, cb),
   },
 };
 

--- a/src/renderer-control/App.tsx
+++ b/src/renderer-control/App.tsx
@@ -6,6 +6,7 @@ import { SetupPage, type LogEntry } from './components/SetupPage';
 import { useLocale } from './i18n';
 import type {
   ApiKeyTestResult,
+  AssemblyConfigPayload,
   DisplayInfo,
   DisplayState,
   LanguageChoice,
@@ -77,6 +78,11 @@ declare global {
       };
       tab: {
         onNavigate: (cb: (t: Tab) => void) => () => void;
+      };
+      assembly: {
+        get: () => Promise<AssemblyConfigPayload>;
+        set: (cfg: AssemblyConfigPayload) => Promise<AssemblyConfigPayload>;
+        onChange: (cb: (cfg: AssemblyConfigPayload) => void) => () => void;
       };
     };
   }
@@ -161,6 +167,20 @@ export function App(): JSX.Element {
   const [finalLines, setFinalLines] = useState<string[]>([]);
   const [partial, setPartial] = useState<string | null>(null);
   const [hasKey, setHasKey] = useState(false);
+  const [assemblyConfig, setAssemblyConfigState] = useState<AssemblyConfigPayload>({
+    forceEndpointMs: 5000,
+  });
+
+  useEffect(() => {
+    void window.diffuseur.assembly.get().then(setAssemblyConfigState);
+    const off = window.diffuseur.assembly.onChange(setAssemblyConfigState);
+    return off;
+  }, []);
+
+  const onAssemblyConfigChange = useCallback((cfg: AssemblyConfigPayload) => {
+    setAssemblyConfigState(cfg);
+    void window.diffuseur.assembly.set(cfg);
+  }, []);
 
   const captureRef = useRef<AudioCapture | null>(null);
   const streamStateRef = useRef<StreamState>('idle');
@@ -410,6 +430,8 @@ export function App(): JSX.Element {
               onApiKeyStatusChange={() => {
                 /* status surfaced inline within ApiKeyForm; not yet promoted to sidebar badge */
               }}
+              assemblyConfig={assemblyConfig}
+              onAssemblyConfigChange={onAssemblyConfigChange}
             />
           )}
         </main>

--- a/src/renderer-control/components/SetupPage.tsx
+++ b/src/renderer-control/components/SetupPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactNode } from 'react';
-import type { LanguageChoice, UsageUpdate } from '../../shared/ipc';
+import type { AssemblyConfigPayload, LanguageChoice, UsageUpdate } from '../../shared/ipc';
 import { useT } from '../i18n';
 import { IconCheck, IconExternal, IconEye, IconEyeOff, IconRefresh } from './Icons';
 
@@ -22,6 +22,8 @@ type Props = {
   onSetRate: (rate: number) => void;
   onOpenDashboard: () => void;
   onApiKeyStatusChange: (status: ApiKeyStatus) => void;
+  assemblyConfig: AssemblyConfigPayload;
+  onAssemblyConfigChange: (cfg: AssemblyConfigPayload) => void;
 };
 
 export function SetupPage({
@@ -38,6 +40,8 @@ export function SetupPage({
   onSetRate,
   onOpenDashboard,
   onApiKeyStatusChange,
+  assemblyConfig,
+  onAssemblyConfigChange,
 }: Props): JSX.Element {
   const t = useT();
 
@@ -111,6 +115,44 @@ export function SetupPage({
           <Field label={t.setup.levelLabel} style={{ marginTop: 16 }}>
             <VuMeter level={rms} />
           </Field>
+        </div>
+
+        {/* Transcription tuning */}
+        <div className="card full">
+          <div className="setup-row top">
+            <div>
+              <h3 className="card-title">{t.setup.tuningTitle}</h3>
+              <p className="card-sub">{t.setup.tuningSub}</p>
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10, alignItems: 'flex-end' }}>
+              <div className="label" style={{ alignSelf: 'flex-start' }}>{t.setup.tuningLabel}</div>
+              <div className="seg">
+                {(
+                  [
+                    { v: null, label: t.setup.tuningOptionOff },
+                    { v: 3000, label: t.setup.tuningOptionFast },
+                    { v: 5000, label: t.setup.tuningOptionDefault },
+                    { v: 7000, label: t.setup.tuningOptionRelaxed },
+                  ] as const
+                ).map((o) => {
+                  const active = assemblyConfig.forceEndpointMs === o.v;
+                  return (
+                    <button
+                      key={String(o.v)}
+                      type="button"
+                      className={active ? 'active' : ''}
+                      onClick={() => onAssemblyConfigChange({ forceEndpointMs: o.v })}
+                    >
+                      {o.label}
+                    </button>
+                  );
+                })}
+              </div>
+              <p className="card-sub" style={{ margin: 0, maxWidth: 360, textAlign: 'right' }}>
+                {t.setup.tuningHelp}
+              </p>
+            </div>
+          </div>
         </div>
 
         {/* Costs */}

--- a/src/renderer-control/i18n.tsx
+++ b/src/renderer-control/i18n.tsx
@@ -126,6 +126,14 @@ export type Messages = {
     logSub: string;
     logEmpty: string;
     logClear: string;
+    tuningTitle: string;
+    tuningSub: string;
+    tuningLabel: string;
+    tuningOptionOff: string;
+    tuningOptionFast: string;
+    tuningOptionDefault: string;
+    tuningOptionRelaxed: string;
+    tuningHelp: string;
   };
   log: {
     streamState: (state: string) => string;
@@ -271,6 +279,16 @@ const fr: Messages = {
     logSub: 'Événements récents de cette session.',
     logEmpty: 'Aucun événement.',
     logClear: 'Effacer',
+    tuningTitle: 'Réglage de la transcription',
+    tuningSub:
+      "Pour les orateurs qui parlent vite sans pauses : on force AssemblyAI à valider le texte en cours après ce délai, pour que le public voie le texte défiler plutôt que d'attendre la prochaine respiration.",
+    tuningLabel: 'Validation forcée',
+    tuningOptionOff: 'Désactivée',
+    tuningOptionFast: 'Rapide · 3 s',
+    tuningOptionDefault: 'Par défaut · 5 s',
+    tuningOptionRelaxed: 'Patient · 7 s',
+    tuningHelp:
+      "Plus court = texte plus réactif mais peut couper des mots. Plus long = phrases plus complètes mais l'audience attend davantage. Désactivé = on s'en remet à la détection naturelle de fin de phrase d'AssemblyAI.",
   },
   log: {
     streamState: (state) => `État du flux: ${state}`,
@@ -419,6 +437,16 @@ const en: Messages = {
     logSub: 'Recent events from this session.',
     logEmpty: 'No events yet.',
     logClear: 'Clear',
+    tuningTitle: 'Transcription tuning',
+    tuningSub:
+      "For speakers who talk fast without pausing: force AssemblyAI to commit the in-flight text after this delay, so the audience sees the transcript scroll forward instead of waiting for the next breath.",
+    tuningLabel: 'Force-commit',
+    tuningOptionOff: 'Off',
+    tuningOptionFast: 'Fast · 3 s',
+    tuningOptionDefault: 'Default · 5 s',
+    tuningOptionRelaxed: 'Patient · 7 s',
+    tuningHelp:
+      "Shorter = more responsive text, but can cut words. Longer = more complete sentences, but the audience waits more. Off = rely entirely on AssemblyAI's natural end-of-turn detection.",
   },
   log: {
     streamState: (state) => `Stream state: ${state}`,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -76,6 +76,11 @@ export const IPC = {
   // Main → renderer: instructs the operator UI to switch to a specific
   // tab (e.g. when the user clicks "Settings…" in the native menu).
   TabNavigate: 'tab:navigate',
+
+  // AssemblyAI tuning (force-endpoint watchdog and any future knobs).
+  AssemblyConfigGet: 'assembly:config:get',
+  AssemblyConfigSet: 'assembly:config:set',
+  AssemblyConfigChanged: 'assembly:config:changed',
 } as const;
 
 export type StyleUpdate = Partial<StyleSettings>;
@@ -96,4 +101,8 @@ export type Tab = 'stage' | 'appearance' | 'setup';
 export type LanguageState = {
   choice: LanguageChoice;
   resolved: ResolvedLocale;
+};
+
+export type AssemblyConfigPayload = {
+  forceEndpointMs: number | null;
 };


### PR DESCRIPTION
## What

Surfaces the watchdog from #14 / v1.1.3 as a per-install setting on the **Setup** page. New 'Transcription tuning' card with four options:

| Option | Threshold | When to pick |
|---|---|---|
| **Off** | none | rely entirely on AssemblyAI's natural end-of-turn detection |
| **Fast · 3 s** | 3000 ms | very fast, pause-less speakers; tolerate mid-sentence cuts |
| **Default · 5 s** | 5000 ms | ships as default; balanced |
| **Patient · 7 s** | 7000 ms | sentence integrity over responsiveness |

## Why

Single hard-coded 5 s cuts sentences (sometimes mid-word) — a real complaint after testing live. Some speakers benefit from shorter (very fast guests), others from longer or off (slower hosts). It's per-event tuning rather than a one-size-fits-all default.

## Plumbing

- New `assembly` block in electron-store `PersistedState`, defaulting to `{ forceEndpointMs: 5000 }`.
- New `AssemblyConfigGet / Set / Changed` IPC channels.
- `assemblyai-client.ts` reads the live setting in `scheduleForceEndpoint()` so changes from the UI take effect on the **next turn** — no reconnect, no app restart.
- `null` or `<= 0` disables the watchdog entirely.
- Renderer: `window.diffuseur.assembly.{get, set, onChange}` exposed via preload; new card on `SetupPage` wired through `App.tsx`. Bilingual (FR/EN) strings.

## How to verify

1. `npm run dev` → Setup tab → scroll to **Transcription tuning** (or **Réglage de la transcription** in FR).
2. Pick **Off** → start a broadcast → speak continuously without pause for 15 s. Confirm no force-commit fires; AssemblyAI commits only when you naturally pause.
3. Pick **Fast · 3 s** → repeat → text now lands in 3-second chunks (with the mid-word-cut behaviour you'd expect).
4. Pick **Default · 5 s** → repeat → 5-second chunks, the v1.1.3 behaviour.
5. Toggle while broadcasting → the change applies on the **next** turn, no need to stop and restart.

## Follow-up potential

Web research (separate report) suggests **client-side VAD-driven endpoint** (run a local Silero / WebRTC VAD, fire ForceEndpoint only on a real sub-300 ms silence dip) avoids mid-word cuts entirely. Out of scope for this PR but worth considering for a v1.2 if word-cuts remain a complaint.