### PR TITLE
In-app update banner (#19)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,7 +1,7 @@
 import { app, BrowserWindow, globalShortcut, session, systemPreferences } from 'electron';
 import { createControlWindow } from './windows';
 import { registerIpc } from './ipc';
-import { initUpdater, setupUpdateDownloadedPrompt } from './updater';
+import { bindUpdateStatusBroadcast, initUpdater, scheduleAutoCheck } from './updater';
 import { setupAppMenu } from './menu';
 
 if (process.platform === 'darwin') {
@@ -17,9 +17,13 @@ function init(): void {
   // Set up the application menu with "Check for Updates"
   setupAppMenu(() => controlWindow);
   
-  // Initialize the auto-updater (internally guarded to run only once)
+  // Initialize the auto-updater (internally guarded to run only once),
+  // wire status changes through to the renderer banner, and kick off a
+  // quiet background check 5s after launch so we don't compete with
+  // first paint for I/O.
   initUpdater();
-  setupUpdateDownloadedPrompt(() => controlWindow);
+  bindUpdateStatusBroadcast(() => controlWindow);
+  scheduleAutoCheck();
 }
 
 app.whenReady().then(async () => {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, ipcMain, screen, shell } from 'electron';
+import { app, BrowserWindow, ipcMain, screen, shell } from 'electron';
 import {
   IPC,
   type ApiKeyTestResult,
@@ -42,6 +42,13 @@ import { SpeechmaticsClient } from './speechmatics-client';
 import type { STTClient, STTClientCallbacks } from './stt-client';
 import { usageTracker } from './usage';
 import { createDisplayWindow } from './windows';
+import {
+  getUpdateStatus,
+  installNow,
+  openReleasesPage,
+  requestDownload,
+  shouldOpenReleasesInsteadOfInstall,
+} from './updater';
 
 type AppContext = {
   controlWindow: BrowserWindow;
@@ -218,6 +225,29 @@ export function registerIpc(controlWindow: BrowserWindow): void {
     const next = setTranscriptionLanguage(payload.language);
     broadcast(IPC.TranscriptionLanguageChanged, { language: next });
     return { language: next };
+  });
+
+  ipcMain.handle(IPC.AppVersionGet, () => app.getVersion());
+
+  ipcMain.handle(IPC.UpdateStatusGet, () => getUpdateStatus());
+  ipcMain.handle(IPC.UpdateDownload, async () => {
+    await requestDownload();
+    return { ok: true };
+  });
+  ipcMain.handle(IPC.UpdateInstall, () => {
+    // On unsigned macOS the swap-on-restart silently fails, so route the
+    // user to the GitHub Releases page instead. Windows uses the real
+    // electron-updater install flow.
+    if (shouldOpenReleasesInsteadOfInstall()) {
+      openReleasesPage();
+    } else {
+      installNow();
+    }
+    return { ok: true };
+  });
+  ipcMain.handle(IPC.UpdateOpenReleases, () => {
+    openReleasesPage();
+    return { ok: true };
   });
 
   ipcMain.handle(IPC.ApiKeyStatus, (_e, payload: { provider: Provider }) => ({

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1,5 +1,6 @@
 import { autoUpdater, type UpdateCheckResult, type UpdateInfo } from 'electron-updater';
 import { BrowserWindow, dialog, app, shell, type MessageBoxOptions } from 'electron';
+import { IPC } from '../shared/ipc';
 
 // In-place auto-install on macOS requires the app to be signed with an Apple
 // Developer ID. Squirrel.framework (used by electron-updater on macOS) verifies
@@ -110,11 +111,20 @@ type UpdateListener = (status: UpdateStatus) => void;
 let currentStatus: UpdateStatus = { type: 'idle' };
 const listeners: Set<UpdateListener> = new Set();
 let updaterInitialized = false;
-let downloadPromptInitialized = false;
+let getStatusBroadcastWindow: (() => BrowserWindow | null) | null = null;
 
 function setStatus(status: UpdateStatus): void {
   currentStatus = status;
   listeners.forEach((listener) => listener(status));
+  // Push the new state to the renderer so the in-app banner can react.
+  const win = getStatusBroadcastWindow?.();
+  if (win && !win.isDestroyed()) {
+    win.webContents.send(IPC.UpdateStatusChanged, status);
+  }
+}
+
+export function bindUpdateStatusBroadcast(getWindow: () => BrowserWindow | null): void {
+  getStatusBroadcastWindow = getWindow;
 }
 
 async function showDialog(
@@ -191,6 +201,37 @@ export function getUpdateStatus(): UpdateStatus {
 export function onUpdateStatus(listener: UpdateListener): () => void {
   listeners.add(listener);
   return () => listeners.delete(listener);
+}
+
+// Quietly check for updates a few seconds after launch. The result lands
+// in the renderer through setStatus → IPC.UpdateStatusChanged, which
+// drives the sidebar banner. Errors are swallowed; a failed background
+// check should never bother the user (they can still trigger an
+// interactive check from the menu).
+const AUTO_CHECK_DELAY_MS = 5000;
+
+export function scheduleAutoCheck(): void {
+  setTimeout(() => {
+    void autoUpdater.checkForUpdates().catch(() => {
+      // ignore — silent failure for background check
+    });
+  }, AUTO_CHECK_DELAY_MS);
+}
+
+export function openReleasesPage(): void {
+  void shell.openExternal(RELEASES_URL);
+}
+
+// Triggered from the renderer banner when the user clicks "Download &
+// install". autoUpdater drives status events that propagate back to the
+// banner via setStatus → IPC.UpdateStatusChanged.
+export async function requestDownload(): Promise<void> {
+  try {
+    await autoUpdater.downloadUpdate();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : tr().unknownError;
+    setStatus({ type: 'error', message });
+  }
 }
 
 export async function checkForUpdatesInteractive(parentWindow: BrowserWindow | null): Promise<void> {
@@ -271,48 +312,13 @@ export async function checkForUpdatesInteractive(parentWindow: BrowserWindow | n
   }
 }
 
-export function setupUpdateDownloadedPrompt(getWindow: () => BrowserWindow | null): void {
-  // Ensure we only register the prompt handler once
-  if (downloadPromptInitialized) return;
-  downloadPromptInitialized = true;
+// Triggered by the renderer banner once a download has finished. Replaces
+// the old auto-firing system modal — the banner is the user's signal that
+// the update is ready, and clicking "Restart now" routes here.
+export function installNow(): void {
+  autoUpdater.quitAndInstall(false, true);
+}
 
-  autoUpdater.on('update-downloaded', async (info: UpdateInfo) => {
-    const s = tr();
-    // On unsigned macOS builds the swap-on-restart will silently fail and
-    // relaunch the old version. Don't pretend it works — point at GitHub
-    // instead. (Belt-and-suspenders: the interactive check already short-
-    // circuits before downloading, but if anything else triggers a download
-    // this guard keeps the broken UX out of users' way.)
-    if (shouldUseManualMacFlow()) {
-      const parentWindow = getWindow();
-      const response = await showDialog(parentWindow, {
-        type: 'info',
-        title: s.updateReady,
-        message: s.versionDownloaded(info.version),
-        detail: s.macInstallReadyDetail,
-        buttons: [s.openGithub, s.later],
-        defaultId: 0,
-        cancelId: 1,
-      });
-      if (response.response === 0) {
-        await shell.openExternal(RELEASES_URL);
-      }
-      return;
-    }
-
-    const parentWindow = getWindow();
-    const response = await showDialog(parentWindow, {
-      type: 'info',
-      title: s.updateReady,
-      message: s.versionDownloaded(info.version),
-      detail: s.restartToApply,
-      buttons: [s.restartNow, s.later],
-      defaultId: 0,
-      cancelId: 1,
-    });
-
-    if (response.response === 0) {
-      autoUpdater.quitAndInstall(false, true);
-    }
-  });
+export function shouldOpenReleasesInsteadOfInstall(): boolean {
+  return shouldUseManualMacFlow();
 }

--- a/src/preload/control.ts
+++ b/src/preload/control.ts
@@ -18,6 +18,7 @@ import type {
   TranscriptPartial,
   TranscriptionLanguage,
   TranscriptionLanguageState,
+  UpdateStatus,
   UsageUpdate,
 } from '../shared/ipc';
 import { IPC } from '../shared/ipc';
@@ -109,6 +110,17 @@ const api = {
   },
   tab: {
     onNavigate: (cb: (t: Tab) => void) => subscribe<Tab>(IPC.TabNavigate, cb),
+  },
+  app: {
+    getVersion: (): Promise<string> => ipcRenderer.invoke(IPC.AppVersionGet),
+  },
+  update: {
+    get: (): Promise<UpdateStatus> => ipcRenderer.invoke(IPC.UpdateStatusGet),
+    onStatus: (cb: (s: UpdateStatus) => void) =>
+      subscribe<UpdateStatus>(IPC.UpdateStatusChanged, cb),
+    download: (): Promise<{ ok: boolean }> => ipcRenderer.invoke(IPC.UpdateDownload),
+    install: (): Promise<{ ok: boolean }> => ipcRenderer.invoke(IPC.UpdateInstall),
+    openReleases: (): Promise<{ ok: boolean }> => ipcRenderer.invoke(IPC.UpdateOpenReleases),
   },
 };
 

--- a/src/renderer-control/App.tsx
+++ b/src/renderer-control/App.tsx
@@ -93,6 +93,16 @@ declare global {
       tab: {
         onNavigate: (cb: (t: Tab) => void) => () => void;
       };
+      app: {
+        getVersion: () => Promise<string>;
+      };
+      update: {
+        get: () => Promise<import('../shared/ipc').UpdateStatus>;
+        onStatus: (cb: (s: import('../shared/ipc').UpdateStatus) => void) => () => void;
+        download: () => Promise<{ ok: boolean }>;
+        install: () => Promise<{ ok: boolean }>;
+        openReleases: () => Promise<{ ok: boolean }>;
+      };
     };
   }
 }
@@ -202,6 +212,11 @@ export function App(): JSX.Element {
   const setTranscriptionLanguage = useCallback((next: TranscriptionLanguage) => {
     setTranscriptionLanguageState(next);
     void window.diffuseur.transcriptionLanguage.set(next);
+  }, []);
+
+  const [appVersion, setAppVersion] = useState<string>('');
+  useEffect(() => {
+    void window.diffuseur.app.getVersion().then(setAppVersion);
   }, []);
 
   const captureRef = useRef<AudioCapture | null>(null);
@@ -409,6 +424,7 @@ export function App(): JSX.Element {
           cycleLanguage={cycleLanguage}
           theme={theme}
           setTheme={setTheme}
+          appVersion={appVersion}
         />
 
         <main className="main">

--- a/src/renderer-control/components/Icons.tsx
+++ b/src/renderer-control/components/Icons.tsx
@@ -104,6 +104,19 @@ export const IconClose = (p: IconProps) => (
   </Svg>
 );
 
+// Party popper — cone with confetti streamers, used for celebratory
+// states like "update available" or "broadcast started".
+export const IconParty = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M3 21l3.5-10.5 7 7L3 21z" />
+    <path d="M14 9l3-3" />
+    <path d="M17 4l1-1" />
+    <path d="M20 7l1.5-.5" />
+    <path d="M19 12l2 0" />
+    <path d="M15 6l.5 1.5" />
+  </Svg>
+);
+
 export const IconRefresh = (p: IconProps) => (
   <Svg {...p}>
     <path d="M21 12a9 9 0 1 1-3-6.7L21 8" />

--- a/src/renderer-control/components/Icons.tsx
+++ b/src/renderer-control/components/Icons.tsx
@@ -98,6 +98,12 @@ export const IconCheck = (p: IconProps) => (
   </Svg>
 );
 
+export const IconClose = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M6 6l12 12M18 6L6 18" />
+  </Svg>
+);
+
 export const IconRefresh = (p: IconProps) => (
   <Svg {...p}>
     <path d="M21 12a9 9 0 1 1-3-6.7L21 8" />

--- a/src/renderer-control/components/Sidebar.tsx
+++ b/src/renderer-control/components/Sidebar.tsx
@@ -80,12 +80,14 @@ export function Sidebar({
         );
       })}
 
-      <div className="sidebar-foot">
+      <div className="sidebar-bottom">
         <UpdateBanner />
-        <div className="status-row">
-          <span className={`dot ${broadcastDot}`} aria-hidden="true" />
-          <span>{broadcastText}</span>
-        </div>
+
+        <div className="sidebar-foot">
+          <div className="status-row">
+            <span className={`dot ${broadcastDot}`} aria-hidden="true" />
+            <span>{broadcastText}</span>
+          </div>
         <div className="status-row">
           <span className={`dot ${displayOpen ? 'ok' : 'idle'}`} aria-hidden="true" />
           <span>
@@ -119,6 +121,7 @@ export function Sidebar({
               <IconMoon size={12} />
             </span>
           </button>
+        </div>
         </div>
       </div>
     </aside>

--- a/src/renderer-control/components/Sidebar.tsx
+++ b/src/renderer-control/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import type { LanguageChoice, StreamState, Tab, Theme } from '../../shared/ipc';
 import { useT } from '../i18n';
 import { IconStage, IconAppearance, IconSetup, IconGlobe, IconSun, IconMoon } from './Icons';
+import { UpdateBanner } from './UpdateBanner';
 
 type Props = {
   tab: Tab;
@@ -13,6 +14,7 @@ type Props = {
   cycleLanguage: () => void;
   theme: Theme;
   setTheme: (theme: Theme) => void;
+  appVersion: string;
 };
 
 export function Sidebar({
@@ -26,6 +28,7 @@ export function Sidebar({
   cycleLanguage,
   theme,
   setTheme,
+  appVersion,
 }: Props): JSX.Element {
   const t = useT();
   const broadcasting = streamState === 'streaming';
@@ -57,7 +60,7 @@ export function Sidebar({
           </svg>
         </div>
         <div className="brand-name">murmure</div>
-        <div className="brand-version">v 1.1.3</div>
+        <div className="brand-version">v {appVersion}</div>
       </div>
 
       <div className="nav-label">{t.brand.workspace}</div>
@@ -78,6 +81,7 @@ export function Sidebar({
       })}
 
       <div className="sidebar-foot">
+        <UpdateBanner />
         <div className="status-row">
           <span className={`dot ${broadcastDot}`} aria-hidden="true" />
           <span>{broadcastText}</span>

--- a/src/renderer-control/components/UpdateBanner.tsx
+++ b/src/renderer-control/components/UpdateBanner.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useState } from 'react';
+import type { UpdateStatus } from '../../shared/ipc';
+import { useT } from '../i18n';
+import { IconClose, IconExternal, IconRefresh } from './Icons';
+
+const DISMISSED_PREFIX = 'murmure.update.dismissed.';
+// Detect the manual-only macOS flow once; the renderer doesn't otherwise
+// need to know the platform. Falls back to false (= can install in place)
+// if navigator.platform is somehow unavailable.
+const isManualMacFlow = (() => {
+  if (typeof navigator === 'undefined') return false;
+  return /mac/i.test(navigator.platform ?? navigator.userAgent ?? '');
+})();
+
+export function UpdateBanner(): JSX.Element | null {
+  const t = useT();
+  const [status, setStatus] = useState<UpdateStatus>({ type: 'idle' });
+  const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
+
+  useEffect(() => {
+    void window.diffuseur.update.get().then((s) => setStatus(s));
+    const off = window.diffuseur.update.onStatus((s) => setStatus(s));
+    return off;
+  }, []);
+
+  const versionInPlay = versionFromStatus(status);
+  // Hide if there's nothing to show, or if the user dismissed *this exact*
+  // version — a later release will re-show because the version key changes.
+  if (!shouldShow(status)) return null;
+  if (versionInPlay && dismissedVersion === versionInPlay) return null;
+
+  const dismiss = () => {
+    if (versionInPlay) {
+      try {
+        window.localStorage.setItem(`${DISMISSED_PREFIX}${versionInPlay}`, '1');
+      } catch {
+        /* ignore quota / private mode */
+      }
+    }
+    setDismissedVersion(versionInPlay ?? null);
+  };
+
+  return (
+    <div className={`update-banner update-banner-${status.type}`} role="status">
+      <BannerBody status={status} t={t} />
+      <BannerActions status={status} t={t} onDismiss={dismiss} />
+    </div>
+  );
+}
+
+function BannerBody({ status, t }: { status: UpdateStatus; t: ReturnType<typeof useT> }): JSX.Element {
+  switch (status.type) {
+    case 'available':
+      return (
+        <div className="update-banner-text">
+          <div className="update-banner-title">{t.update.available(status.version)}</div>
+        </div>
+      );
+    case 'downloading':
+      return (
+        <div className="update-banner-text">
+          <div className="update-banner-title">{t.update.downloading(status.percent)}</div>
+          <div className="update-banner-progress" aria-hidden="true">
+            <div className="update-banner-progress-fill" style={{ width: `${status.percent}%` }} />
+          </div>
+        </div>
+      );
+    case 'downloaded':
+      return (
+        <div className="update-banner-text">
+          <div className="update-banner-title">{t.update.readyToRestart}</div>
+        </div>
+      );
+    case 'error':
+      return (
+        <div className="update-banner-text">
+          <div className="update-banner-title">{t.update.failed}</div>
+        </div>
+      );
+    default:
+      return <div className="update-banner-text" />;
+  }
+}
+
+function BannerActions({
+  status,
+  t,
+  onDismiss,
+}: {
+  status: UpdateStatus;
+  t: ReturnType<typeof useT>;
+  onDismiss: () => void;
+}): JSX.Element {
+  const dismissBtn = (
+    <button
+      type="button"
+      className="update-banner-dismiss"
+      onClick={onDismiss}
+      aria-label={t.update.dismiss}
+      title={t.update.dismiss}
+    >
+      <IconClose size={11} />
+    </button>
+  );
+
+  // Useful action depends on platform + state. macOS without Developer ID
+  // can't swap-on-restart, so we send the user to GitHub instead of
+  // attempting an install that would silently fall back to the old binary.
+  if (status.type === 'available') {
+    return (
+      <div className="update-banner-actions">
+        <button
+          type="button"
+          className="update-banner-cta"
+          onClick={() => {
+            if (isManualMacFlow) void window.diffuseur.update.openReleases();
+            else void window.diffuseur.update.download();
+          }}
+        >
+          {isManualMacFlow ? <IconExternal size={11} /> : null}
+          {isManualMacFlow ? t.update.viewReleaseNotes : t.update.downloadInstall}
+        </button>
+        {dismissBtn}
+      </div>
+    );
+  }
+  if (status.type === 'downloaded') {
+    return (
+      <div className="update-banner-actions">
+        <button
+          type="button"
+          className="update-banner-cta"
+          onClick={() => void window.diffuseur.update.install()}
+        >
+          {t.update.restartNow}
+        </button>
+        {dismissBtn}
+      </div>
+    );
+  }
+  if (status.type === 'error') {
+    return (
+      <div className="update-banner-actions">
+        <button
+          type="button"
+          className="update-banner-cta"
+          onClick={() => void window.diffuseur.update.download()}
+        >
+          <IconRefresh size={11} />
+          {t.update.retry}
+        </button>
+        {dismissBtn}
+      </div>
+    );
+  }
+  // Downloading — only allow dismiss (download keeps going in main; user
+  // can come back to it via the menu's "Check for Updates" if they dismiss).
+  return <div className="update-banner-actions">{dismissBtn}</div>;
+}
+
+function shouldShow(status: UpdateStatus): boolean {
+  return (
+    status.type === 'available' ||
+    status.type === 'downloading' ||
+    status.type === 'downloaded' ||
+    status.type === 'error'
+  );
+}
+
+function versionFromStatus(status: UpdateStatus): string | null {
+  if (status.type === 'available' || status.type === 'downloaded') return status.version;
+  return null;
+}

--- a/src/renderer-control/components/UpdateBanner.tsx
+++ b/src/renderer-control/components/UpdateBanner.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { UpdateStatus } from '../../shared/ipc';
 import { useT } from '../i18n';
-import { IconClose, IconExternal, IconRefresh } from './Icons';
+import { IconClose, IconExternal, IconParty, IconRefresh } from './Icons';
 
 const DISMISSED_PREFIX = 'murmure.update.dismissed.';
 // Detect the manual-only macOS flow once; the renderer doesn't otherwise
@@ -40,122 +40,105 @@ export function UpdateBanner(): JSX.Element | null {
     setDismissedVersion(versionInPlay ?? null);
   };
 
+  const view = bannerView(status, t);
+
   return (
     <div className={`update-banner update-banner-${status.type}`} role="status">
-      <BannerBody status={status} t={t} />
-      <BannerActions status={status} t={t} onDismiss={dismiss} />
+      <button
+        type="button"
+        className="update-banner-dismiss"
+        onClick={dismiss}
+        aria-label={t.update.dismiss}
+        title={t.update.dismiss}
+      >
+        <IconClose size={10} />
+      </button>
+
+      <div className="update-banner-head">
+        <span className="update-banner-icon" aria-hidden="true">
+          {view.icon}
+        </span>
+        <h3 className="update-banner-title">{view.title}</h3>
+      </div>
+
+      {view.body && <p className="update-banner-body">{view.body}</p>}
+
+      {status.type === 'downloading' && (
+        <div className="update-banner-progress" aria-hidden="true">
+          <div
+            className="update-banner-progress-fill"
+            style={{ width: `${status.percent}%` }}
+          />
+        </div>
+      )}
+
+      {view.cta && (
+        <button type="button" className="update-banner-cta" onClick={view.cta.onClick}>
+          {view.cta.icon}
+          <span>{view.cta.label}</span>
+        </button>
+      )}
     </div>
   );
 }
 
-function BannerBody({ status, t }: { status: UpdateStatus; t: ReturnType<typeof useT> }): JSX.Element {
+type BannerView = {
+  icon: JSX.Element;
+  title: string;
+  body: string | null;
+  cta: { label: string; onClick: () => void; icon?: JSX.Element } | null;
+};
+
+function bannerView(status: UpdateStatus, t: ReturnType<typeof useT>): BannerView {
   switch (status.type) {
     case 'available':
-      return (
-        <div className="update-banner-text">
-          <div className="update-banner-title">{t.update.available(status.version)}</div>
-        </div>
-      );
+      return {
+        icon: <IconParty size={14} />,
+        title: t.update.availableTitle,
+        body: t.update.availableBody(status.version),
+        cta: isManualMacFlow
+          ? {
+              label: t.update.viewReleaseNotes,
+              icon: <IconExternal size={12} />,
+              onClick: () => void window.diffuseur.update.openReleases(),
+            }
+          : {
+              label: t.update.downloadInstall,
+              icon: <IconExternal size={12} />,
+              onClick: () => void window.diffuseur.update.download(),
+            },
+      };
     case 'downloading':
-      return (
-        <div className="update-banner-text">
-          <div className="update-banner-title">{t.update.downloading(status.percent)}</div>
-          <div className="update-banner-progress" aria-hidden="true">
-            <div className="update-banner-progress-fill" style={{ width: `${status.percent}%` }} />
-          </div>
-        </div>
-      );
+      return {
+        icon: <IconRefresh size={14} />,
+        title: t.update.downloadingTitle,
+        body: t.update.downloadingBody(status.percent),
+        cta: null,
+      };
     case 'downloaded':
-      return (
-        <div className="update-banner-text">
-          <div className="update-banner-title">{t.update.readyToRestart}</div>
-        </div>
-      );
+      return {
+        icon: <IconParty size={14} />,
+        title: t.update.readyTitle,
+        body: t.update.readyBody,
+        cta: {
+          label: t.update.restartNow,
+          onClick: () => void window.diffuseur.update.install(),
+        },
+      };
     case 'error':
-      return (
-        <div className="update-banner-text">
-          <div className="update-banner-title">{t.update.failed}</div>
-        </div>
-      );
+      return {
+        icon: <IconRefresh size={14} />,
+        title: t.update.failedTitle,
+        body: t.update.failedBody,
+        cta: {
+          label: t.update.retry,
+          icon: <IconRefresh size={12} />,
+          onClick: () => void window.diffuseur.update.download(),
+        },
+      };
     default:
-      return <div className="update-banner-text" />;
+      return { icon: <IconParty size={14} />, title: '', body: null, cta: null };
   }
-}
-
-function BannerActions({
-  status,
-  t,
-  onDismiss,
-}: {
-  status: UpdateStatus;
-  t: ReturnType<typeof useT>;
-  onDismiss: () => void;
-}): JSX.Element {
-  const dismissBtn = (
-    <button
-      type="button"
-      className="update-banner-dismiss"
-      onClick={onDismiss}
-      aria-label={t.update.dismiss}
-      title={t.update.dismiss}
-    >
-      <IconClose size={11} />
-    </button>
-  );
-
-  // Useful action depends on platform + state. macOS without Developer ID
-  // can't swap-on-restart, so we send the user to GitHub instead of
-  // attempting an install that would silently fall back to the old binary.
-  if (status.type === 'available') {
-    return (
-      <div className="update-banner-actions">
-        <button
-          type="button"
-          className="update-banner-cta"
-          onClick={() => {
-            if (isManualMacFlow) void window.diffuseur.update.openReleases();
-            else void window.diffuseur.update.download();
-          }}
-        >
-          {isManualMacFlow ? <IconExternal size={11} /> : null}
-          {isManualMacFlow ? t.update.viewReleaseNotes : t.update.downloadInstall}
-        </button>
-        {dismissBtn}
-      </div>
-    );
-  }
-  if (status.type === 'downloaded') {
-    return (
-      <div className="update-banner-actions">
-        <button
-          type="button"
-          className="update-banner-cta"
-          onClick={() => void window.diffuseur.update.install()}
-        >
-          {t.update.restartNow}
-        </button>
-        {dismissBtn}
-      </div>
-    );
-  }
-  if (status.type === 'error') {
-    return (
-      <div className="update-banner-actions">
-        <button
-          type="button"
-          className="update-banner-cta"
-          onClick={() => void window.diffuseur.update.download()}
-        >
-          <IconRefresh size={11} />
-          {t.update.retry}
-        </button>
-        {dismissBtn}
-      </div>
-    );
-  }
-  // Downloading — only allow dismiss (download keeps going in main; user
-  // can come back to it via the menu's "Check for Updates" if they dismiss).
-  return <div className="update-banner-actions">{dismissBtn}</div>;
 }
 
 function shouldShow(status: UpdateStatus): boolean {

--- a/src/renderer-control/i18n.tsx
+++ b/src/renderer-control/i18n.tsx
@@ -144,6 +144,17 @@ export type Messages = {
   toast: { newScreen: string; screenLost: string };
   languagePill: { tooltip: string };
   themeToggle: { tooltip: string };
+  update: {
+    available: (version: string) => string;
+    viewReleaseNotes: string;
+    downloadInstall: string;
+    downloading: (percent: number) => string;
+    readyToRestart: string;
+    restartNow: string;
+    dismiss: string;
+    failed: string;
+    retry: string;
+  };
 };
 
 const fr: Messages = {
@@ -315,6 +326,17 @@ const fr: Messages = {
   },
   languagePill: { tooltip: 'Changer de langue' },
   themeToggle: { tooltip: 'Changer le thème' },
+  update: {
+    available: (v) => `Mise à jour disponible · v${v}`,
+    viewReleaseNotes: 'Voir sur GitHub',
+    downloadInstall: 'Télécharger',
+    downloading: (p) => `Téléchargement… ${Math.round(p)}%`,
+    readyToRestart: 'Prête à installer',
+    restartNow: 'Redémarrer',
+    dismiss: 'Ignorer',
+    failed: 'Échec de la mise à jour',
+    retry: 'Réessayer',
+  },
 };
 
 const en: Messages = {
@@ -486,6 +508,17 @@ const en: Messages = {
   },
   languagePill: { tooltip: 'Switch language' },
   themeToggle: { tooltip: 'Switch theme' },
+  update: {
+    available: (v) => `Update available · v${v}`,
+    viewReleaseNotes: 'View on GitHub',
+    downloadInstall: 'Download',
+    downloading: (p) => `Downloading… ${Math.round(p)}%`,
+    readyToRestart: 'Ready to install',
+    restartNow: 'Restart',
+    dismiss: 'Dismiss',
+    failed: 'Update failed',
+    retry: 'Retry',
+  },
 };
 
 const dictionaries: Record<Locale, Messages> = { fr, en };

--- a/src/renderer-control/i18n.tsx
+++ b/src/renderer-control/i18n.tsx
@@ -145,14 +145,18 @@ export type Messages = {
   languagePill: { tooltip: string };
   themeToggle: { tooltip: string };
   update: {
-    available: (version: string) => string;
+    availableTitle: string;
+    availableBody: (version: string) => string;
     viewReleaseNotes: string;
     downloadInstall: string;
-    downloading: (percent: number) => string;
-    readyToRestart: string;
+    downloadingTitle: string;
+    downloadingBody: (percent: number) => string;
+    readyTitle: string;
+    readyBody: string;
     restartNow: string;
     dismiss: string;
-    failed: string;
+    failedTitle: string;
+    failedBody: string;
     retry: string;
   };
 };
@@ -327,14 +331,18 @@ const fr: Messages = {
   languagePill: { tooltip: 'Changer de langue' },
   themeToggle: { tooltip: 'Changer le thème' },
   update: {
-    available: (v) => `Mise à jour disponible · v${v}`,
+    availableTitle: 'Mise à jour disponible',
+    availableBody: (v) => `murmure ${v} est disponible !`,
     viewReleaseNotes: 'Voir sur GitHub',
     downloadInstall: 'Télécharger',
-    downloading: (p) => `Téléchargement… ${Math.round(p)}%`,
-    readyToRestart: 'Prête à installer',
+    downloadingTitle: 'Téléchargement…',
+    downloadingBody: (p) => `${Math.round(p)} %`,
+    readyTitle: 'Prête à installer',
+    readyBody: 'Redémarrez pour appliquer la nouvelle version.',
     restartNow: 'Redémarrer',
     dismiss: 'Ignorer',
-    failed: 'Échec de la mise à jour',
+    failedTitle: 'Échec de la mise à jour',
+    failedBody: 'Réessayez dans un instant.',
     retry: 'Réessayer',
   },
 };
@@ -509,14 +517,18 @@ const en: Messages = {
   languagePill: { tooltip: 'Switch language' },
   themeToggle: { tooltip: 'Switch theme' },
   update: {
-    available: (v) => `Update available · v${v}`,
+    availableTitle: 'Update available',
+    availableBody: (v) => `murmure ${v} is now live!`,
     viewReleaseNotes: 'View on GitHub',
     downloadInstall: 'Download',
-    downloading: (p) => `Downloading… ${Math.round(p)}%`,
-    readyToRestart: 'Ready to install',
+    downloadingTitle: 'Downloading…',
+    downloadingBody: (p) => `${Math.round(p)}%`,
+    readyTitle: 'Ready to install',
+    readyBody: 'Restart to apply the new version.',
     restartNow: 'Restart',
     dismiss: 'Dismiss',
-    failed: 'Update failed',
+    failedTitle: 'Update failed',
+    failedBody: 'Try again in a moment.',
     retry: 'Retry',
   },
 };

--- a/src/renderer-control/styles.css
+++ b/src/renderer-control/styles.css
@@ -245,8 +245,12 @@ a { color: var(--brand); text-decoration: none; }
   letter-spacing: 0.04em;
 }
 
-.sidebar-foot {
+.sidebar-bottom {
   margin-top: auto;
+  display: flex;
+  flex-direction: column;
+}
+.sidebar-foot {
   padding: 10px 8px 4px;
   border-top: 1px solid var(--line);
   display: flex;
@@ -255,58 +259,77 @@ a { color: var(--brand); text-decoration: none; }
 }
 
 .update-banner {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 10px;
-  margin: 0 -2px 4px;
+  align-items: center;
+  text-align: center;
+  gap: 6px;
+  padding: 18px 14px 14px;
+  margin: 0 6px 12px;
   background: var(--brand-soft);
   border: 1px solid var(--brand-line);
-  border-radius: 8px;
-  animation: update-banner-in 240ms cubic-bezier(0.2, 0.6, 0.2, 1) both;
+  border-radius: 12px;
+  animation: update-banner-in 280ms cubic-bezier(0.2, 0.6, 0.2, 1) both;
 }
 @keyframes update-banner-in {
   from { opacity: 0; transform: translateY(4px); }
   to { opacity: 1; transform: translateY(0); }
 }
+.update-banner-head {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--brand);
+}
+.update-banner-icon {
+  display: inline-flex;
+  flex-shrink: 0;
+}
 .update-banner-title {
-  font-size: 11.5px;
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: 15px;
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  color: var(--brand);
+  margin: 0;
+  white-space: nowrap;
+}
+.update-banner-body {
+  font-size: 12px;
   color: var(--ink);
-  font-weight: 500;
-  line-height: 1.35;
-  letter-spacing: 0.005em;
+  margin: 0;
+  line-height: 1.4;
+  max-width: 100%;
 }
 .update-banner-progress {
-  margin-top: 6px;
+  width: 100%;
   height: 3px;
-  background: rgba(39, 69, 207, 0.15);
+  background: rgba(39, 69, 207, 0.18);
   border-radius: 2px;
   overflow: hidden;
+  margin-top: 2px;
 }
 .update-banner-progress-fill {
   height: 100%;
   background: var(--brand);
   transition: width 200ms ease;
 }
-.update-banner-actions {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
 .update-banner-cta {
-  flex: 1;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 5px;
+  gap: 6px;
+  margin-top: 6px;
   border: 0;
-  padding: 7px 10px;
+  padding: 8px 16px;
   background: var(--brand);
   color: #fff;
   font-family: inherit;
-  font-size: 11.5px;
+  font-size: 12.5px;
   font-weight: 500;
-  border-radius: 6px;
+  border-radius: 8px;
   cursor: pointer;
   transition: filter 120ms var(--ease), transform 60ms var(--ease);
 }
@@ -317,24 +340,32 @@ a { color: var(--brand); text-decoration: none; }
   transform: translateY(0.5px);
 }
 .update-banner-dismiss {
-  flex-shrink: 0;
-  width: 24px;
-  height: 24px;
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 18px;
+  height: 18px;
   border: 0;
   background: transparent;
-  color: var(--ink-3);
+  color: var(--brand);
+  opacity: 0.4;
   border-radius: 6px;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: background 120ms var(--ease), color 120ms var(--ease);
+  transition: background 120ms var(--ease), opacity 120ms var(--ease);
 }
+.update-banner:hover .update-banner-dismiss,
 .update-banner-dismiss:hover {
   background: rgba(39, 69, 207, 0.10);
-  color: var(--ink);
+  opacity: 1;
 }
+.update-banner-error .update-banner-head,
 .update-banner-error .update-banner-title {
+  color: var(--accent-warm);
+}
+.update-banner-error .update-banner-dismiss {
   color: var(--accent-warm);
 }
 @media (prefers-reduced-motion: reduce) {

--- a/src/renderer-control/styles.css
+++ b/src/renderer-control/styles.css
@@ -254,6 +254,98 @@ a { color: var(--brand); text-decoration: none; }
   gap: 8px;
 }
 
+.update-banner {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  margin: 0 -2px 4px;
+  background: var(--brand-soft);
+  border: 1px solid var(--brand-line);
+  border-radius: 8px;
+  animation: update-banner-in 240ms cubic-bezier(0.2, 0.6, 0.2, 1) both;
+}
+@keyframes update-banner-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.update-banner-title {
+  font-size: 11.5px;
+  color: var(--ink);
+  font-weight: 500;
+  line-height: 1.35;
+  letter-spacing: 0.005em;
+}
+.update-banner-progress {
+  margin-top: 6px;
+  height: 3px;
+  background: rgba(39, 69, 207, 0.15);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.update-banner-progress-fill {
+  height: 100%;
+  background: var(--brand);
+  transition: width 200ms ease;
+}
+.update-banner-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.update-banner-cta {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  border: 0;
+  padding: 7px 10px;
+  background: var(--brand);
+  color: #fff;
+  font-family: inherit;
+  font-size: 11.5px;
+  font-weight: 500;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: filter 120ms var(--ease), transform 60ms var(--ease);
+}
+.update-banner-cta:hover {
+  filter: brightness(1.08);
+}
+.update-banner-cta:active {
+  transform: translateY(0.5px);
+}
+.update-banner-dismiss {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  border: 0;
+  background: transparent;
+  color: var(--ink-3);
+  border-radius: 6px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 120ms var(--ease), color 120ms var(--ease);
+}
+.update-banner-dismiss:hover {
+  background: rgba(39, 69, 207, 0.10);
+  color: var(--ink);
+}
+.update-banner-error .update-banner-title {
+  color: var(--accent-warm);
+}
+@media (prefers-reduced-motion: reduce) {
+  .update-banner {
+    animation: none;
+  }
+  .update-banner-progress-fill {
+    transition: none;
+  }
+}
+
 .status-row {
   display: flex;
   align-items: center;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -45,6 +45,14 @@ export const IPC = {
   TranscriptionLanguageSet: 'transcription-language:set',
   TranscriptionLanguageChanged: 'transcription-language:changed',
 
+  AppVersionGet: 'app:version:get',
+
+  UpdateStatusGet: 'update:status:get',
+  UpdateStatusChanged: 'update:status:changed',
+  UpdateDownload: 'update:download',
+  UpdateInstall: 'update:install',
+  UpdateOpenReleases: 'update:open-releases',
+
   ApiKeySave: 'apikey:save',
   ApiKeyTest: 'apikey:test',
   ApiKeyClear: 'apikey:clear',
@@ -114,3 +122,14 @@ export type LanguageState = {
   choice: LanguageChoice;
   resolved: ResolvedLocale;
 };
+
+// Mirrors src/main/updater.ts UpdateStatus, redeclared here so the renderer
+// can subscribe without importing from main.
+export type UpdateStatus =
+  | { type: 'idle' }
+  | { type: 'checking' }
+  | { type: 'available'; version: string }
+  | { type: 'not-available' }
+  | { type: 'downloading'; percent: number }
+  | { type: 'downloaded'; version: string }
+  | { type: 'error'; message: string };


### PR DESCRIPTION
Closes #19.

## Summary
- Quiet background update check 5s after launch
- Dismissible banner in the sidebar (above the broadcast status row)
- macOS: \"Voir sur GitHub / View on GitHub\" — opens the Releases page (auto-install requires a Developer ID we don't have yet, so we don't pretend)
- Windows: \"Télécharger / Download\" → in-banner progress bar → \"Redémarrer / Restart\" → quitAndInstall()
- Per-version dismissal stored in localStorage, so a later release re-surfaces
- Brand-block version chip is now read from \`app.getVersion()\` instead of being hardcoded

## What's gone
- The old post-download system modal in \`setupUpdateDownloadedPrompt\`. The banner is the user's signal now; double-prompting was redundant.

## Test plan
- [ ] Boot v1.1.x build → banner shows \"Mise à jour disponible · v1.2.0\" within ~5s
- [ ] macOS: click \"Voir sur GitHub\" → opens https://github.com/KevinGallaccio/murmure/releases/latest in default browser
- [ ] Windows: click \"Télécharger\" → progress fills → \"Redémarrer\" appears → click → app restarts on the new version
- [ ] Dismiss button hides the banner; restarting the app doesn't re-show for the same version
- [ ] Install a third release → banner re-appears for the new version on next launch
- [ ] Brand block shows the running version (not hardcoded \"1.1.3\")
- [ ] Menu \"Check for Updates...\" still works (kept for the deliberate path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)